### PR TITLE
improve the transitionOpacity type

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ interface UseFixedHeaderOptions {
     *
     * @default false
     */
-   transitionOpacity: Ref<boolean> | boolean
+   transitionOpacity: boolean | Ref<boolean> | ComputedRef<boolean>
 }
 ```
 

--- a/packages/vue-use-fixed-header/src/types.ts
+++ b/packages/vue-use-fixed-header/src/types.ts
@@ -22,5 +22,5 @@ export interface UseFixedHeaderOptions<T = any> {
     *
     * @default false
     */
-   transitionOpacity: boolean
+   transitionOpacity: boolean | Ref<boolean> | ComputedRef<boolean>
 }


### PR DESCRIPTION
Greetings!

First of all, I'd like to say thanks for the job you've done! In my opinion, your repos are awesome!

I found that there's currently a TypeScript error when we pass a `ref` or `computed` as the `transitionOpacity` value. And it would be nice to improve the situation, especially because the implementation is ready.

I think the best solution at the moment is to declare it as follows: `boolean | Ref<boolean> | ComputedRef<boolean>`, because `toValue` and related types require 3.3+ from a user.

Before changes: 
![before](https://github.com/smastrom/vue-use-fixed-header/assets/98835787/b20008b1-0e9b-4b9c-b14c-47e2af1e621c)

After:
![after](https://github.com/smastrom/vue-use-fixed-header/assets/98835787/9e50f1c3-0519-4894-be6c-cb2ddc5d9bf6)