### PR TITLE
rm an extra call of getScrollTop

### DIFF
--- a/packages/vue-use-fixed-header/src/useFixedHeader.ts
+++ b/packages/vue-use-fixed-header/src/useFixedHeader.ts
@@ -186,7 +186,7 @@ export function useFixedHeader(
             }
          }
 
-         prevTop = getScrollTop()
+         prevTop = scrollTop
       }
    }
 


### PR DESCRIPTION
Greetings!

I noticed that we can access the existing scrollTop variable instead of calling getScrollTop again. I think it would be a bit better.