### PR TITLE
remove the Readonly wrapper for the ComputedRef

### DIFF
--- a/packages/vue-use-fixed-header/src/useFixedHeader.ts
+++ b/packages/vue-use-fixed-header/src/useFixedHeader.ts
@@ -25,8 +25,8 @@ export function useFixedHeader(
    options: Partial<UseFixedHeaderOptions> = {},
 ): {
    styles: Readonly<CSS>
-   isLeave: Readonly<ComputedRef<boolean>>
-   isEnter: Readonly<ComputedRef<boolean>>
+   isLeave: ComputedRef<boolean>
+   isEnter: ComputedRef<boolean>
 } {
    // Config
 


### PR DESCRIPTION
Greetings!

I found it a bit confusing that the ComputedRef is wrapped by the Readonly. The ComputedRef still cannot be modified, and according to https://github.com/smastrom/vue-use-fixed-header#api, should not be wrapped by the Readonly.